### PR TITLE
Transparent background was not working correcly

### DIFF
--- a/lua/darcubox/groups.lua
+++ b/lua/darcubox/groups.lua
@@ -4,6 +4,7 @@ function M.setup()
   local p = require("darcubox.palette").palette
   local config = require("darcubox").config
   local bg = config.options.transparent and "NONE" or p.bg
+  local contrastbg = config.options.transparent and "NONE" or p.contrast
 
   -- stylua: ignore
   local groups = {
@@ -35,11 +36,11 @@ function M.setup()
     MsgSeparator                         = { fg = p.fg, bg = bg },
     NonText                              = { fg = p.surface2 },
     Normal                               = { fg = p.fg, bg = bg,}, -- Normal text and background color
-    NormalSB                             = { fg = p.surface2, bg = p.contrast }, -- normal text in sidebar
-    NormalNC                             = { fg = p.surface1, bg = p.contrast }, -- normal text in non-current windows
+    NormalSB                             = { fg = p.surface2, bg = contrastbg }, -- normal text in sidebar
+    NormalNC                             = { fg = p.surface1, bg = contrastbg }, -- normal text in non-current windows
     NormalFloat                          = { link = "Normal" }, -- Normal text and background color
-    FloatBorder                          = { fg = p.sand, bg = p.contrast },
-    FloatTitle                           = { fg = p.alabaster, bg = p.contrast },
+    FloatBorder                          = { fg = p.sand, bg = contrastbg },
+    FloatTitle                           = { fg = p.alabaster, bg = contrastbg },
     Pmenu                                = { fg = p.fg, bg = p.surface1 },
     PmenuSel                             = { fg = p.sunshine, bg = p.surface2 },
     PmenuSbar                            = { fg = p.silver, bg = p.surface2 },


### PR DESCRIPTION
Hey @Koalhack,

I've been using the darcubox colorscheme for a while and have been running into some issues with the transparent background, as shown in the screenshot below:
<img width="2014" height="1180" alt="image" src="https://github.com/user-attachments/assets/a79495df-568e-4ddd-9f80-e199d04338ae" />

I've tried configuring it in several different ways to make the transparent background work, but I always get this same error.

To address this, I modified the contrast background variable so that it dynamically matches the transparent. Here’s the result after the change:
<img width="2184" height="1223" alt="image" src="https://github.com/user-attachments/assets/64ce8055-20ba-4ea0-b8ff-55d0a7566006" />
